### PR TITLE
[Step6] 동시성 이슈 해결 과제

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,12 @@ dependencyManagement {
 	}
 }
 
+configurations {
+	testImplementation {
+		exclude(group = "org.slf4j", module = "slf4j-simple")
+	}
+}
+
 dependencies {
     // Spring
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -45,12 +51,14 @@ dependencies {
 	testImplementation("org.testcontainers:mysql")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testImplementation("org.jboss.logging:jboss-logging:3.5.3.Final")
+	testImplementation("it.ozimov:embedded-redis:0.7.3")
 
 	// H2 (인메모리)
 	testImplementation("com.h2database:h2")
 
-	// Redis
+	// Redis - Redisson 사용
 	implementation("org.redisson:redisson-spring-boot-starter:3.24.3")
+
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,9 @@ dependencies {
 
 	// H2 (인메모리)
 	testImplementation("com.h2database:h2")
+
+	// Redis
+	implementation("org.redisson:redisson-spring-boot-starter:3.24.3")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/kr/hhplus/be/server/application/usecase/RechargePointUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/application/usecase/RechargePointUseCase.java
@@ -1,8 +1,11 @@
 package kr.hhplus.be.server.application.usecase;
 
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.hhplus.be.server.config.manager.DistributedLockManager;
 import kr.hhplus.be.server.domain.model.Money;
 import kr.hhplus.be.server.domain.model.PointWallet;
 import kr.hhplus.be.server.domain.port.WalletPort;
@@ -10,9 +13,11 @@ import kr.hhplus.be.server.domain.port.WalletPort;
 @Service
 public class RechargePointUseCase {
 	private final WalletPort walletPort;
+	private final DistributedLockManager lockManager;
 
-	public RechargePointUseCase(WalletPort walletPort) {
+	public RechargePointUseCase(WalletPort walletPort, DistributedLockManager lockManager) {
 		this.walletPort = walletPort;
+		this.lockManager = lockManager;
 	}
 
 	/** 포인트 충전 요청 처리 **/
@@ -36,6 +41,33 @@ public class RechargePointUseCase {
 		walletPort.recordProcessed(userId, requestId, amount, wallet.getBalance());
 
 		return new Result(wallet.getBalance());
+	}
+
+	@Transactional
+	public Result handleWithDistributedLock(Long userId, Money amount, String requestId) {
+		String lockKey = "wallet:recharge:" + userId;
+
+		return lockManager.executeWithLock(
+			lockKey,
+			5,  // waitTime: 5초
+			3,  // leaseTime: 3초 (자동 해제)
+			TimeUnit.SECONDS,
+			() -> {
+				// 멱등성 체크
+				if (walletPort.hasProcessed(userId, requestId)) {
+					PointWallet current = walletPort.findByUserIdForUpdate(userId);
+					return new Result(current.getBalance());
+				}
+
+				// 충전 처리
+				PointWallet wallet = walletPort.findByUserIdForUpdate(userId);
+				wallet.recharge(amount);
+				walletPort.save(wallet);
+				walletPort.recordProcessed(userId, requestId, amount, wallet.getBalance());
+
+				return new Result(wallet.getBalance());
+			}
+		);
 	}
 
 	// Result 객체를 반환하기 위한 record 객체

--- a/src/main/java/kr/hhplus/be/server/config/jpa/RedissonConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/jpa/RedissonConfig.java
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.config.jpa;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		config.useSingleServer()
+			.setAddress("redis://localhost:6379");
+		return Redisson.create(config);
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/config/manager/DistributedLockManager.java
+++ b/src/main/java/kr/hhplus/be/server/config/manager/DistributedLockManager.java
@@ -1,0 +1,42 @@
+package kr.hhplus.be.server.config.manager;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DistributedLockManager {
+	private final RedissonClient redissonClient;
+
+	public DistributedLockManager(RedissonClient redissonClient) {
+		this.redissonClient = redissonClient;
+	}
+
+	/**
+	 lockKey: redis에 저장될 락의 키
+	 waitTime: 락을 얻기 위해 최대 몇 초를 기다릴 지
+	 leaseTime: 락을 획득한 후 자동으로 해제될 시간 (데드락 방지)
+	 timeUnit: 시간 단위task: 락을 획득한 후 실행할 비즈니스 로직
+	**/
+	public <T> T executeWithLock(String lockKey, long waitTime, long leaseTime,
+		TimeUnit timeUnit, Supplier<T> task) {
+		RLock lock = redissonClient.getLock(lockKey);
+		try {
+			boolean acquired = lock.tryLock(waitTime, leaseTime, timeUnit);
+			if (!acquired) {
+				throw new IllegalStateException("락 획득 실패: " + lockKey);
+			}
+			return task.get();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("락 대기 중 인터럽트 발생", e);
+		} finally {
+			if (lock.isHeldByCurrentThread()) {
+				lock.unlock();
+			}
+		}
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/domain/model/Money.java
+++ b/src/main/java/kr/hhplus/be/server/domain/model/Money.java
@@ -15,6 +15,10 @@ public class Money {
 	public boolean equalsAmount(Money other) { return this.amount == other.amount; }
 	public long asLong() { return amount; }
 
+	public Money multiply(int multiplier) {
+		return new Money(this.amount * multiplier);
+	}
+
 	@Override public String toString() { return "KRW " + amount; }
 	@Override public boolean equals(Object o) {
 		if (this == o) return true;

--- a/src/main/java/kr/hhplus/be/server/domain/port/WalletPort.java
+++ b/src/main/java/kr/hhplus/be/server/domain/port/WalletPort.java
@@ -13,4 +13,7 @@ public interface WalletPort {
 
 	Optional<WalletEntity> findById(long userId);
 	void recordProcessed(Long userId, String requestId, Money amount, Money balanceAfter);
+
+	// 분산락 사용시 일반 조회
+	PointWallet findByUserId(Long userId);
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/adapter/WalletJpaAdapter.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/adapter/WalletJpaAdapter.java
@@ -59,7 +59,6 @@ public class WalletJpaAdapter implements WalletPort {
 		return historyJpa.existsByUserIdAndRequestId(userId, requestId);
 	}
 
-
 	/** 포인트 거래 기록 저장 **/
 	// 기록 메서드
 	@Transactional
@@ -84,5 +83,21 @@ public class WalletJpaAdapter implements WalletPort {
 	@Transactional
 	public void recordProcessed(Long userId, String requestId, Money amount, Money balanceAfter) {
 		recordHistory(userId, "RECHARGE", amount, balanceAfter, requestId, null);
+	}
+
+	/** 일반 조회 (분산락 사용시) **/
+	@Override
+	@Transactional(readOnly = true)
+	public PointWallet findByUserId(Long userId) {
+		WalletEntity e = walletJpa.findById(userId)
+			.orElseGet(() -> {
+				// 지갑이 없으면 새로 생성
+				WalletEntity ne = new WalletEntity();
+				ne.id = userId;
+				ne.balance = new MoneyEmbeddable(0);
+				ne.updatedAt = LocalDateTime.now();
+				return walletJpa.save(ne);
+			});
+		return PointWallet.rehydrate(e.id, Money.of(e.balance.amount));
 	}
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/springdata/SpringWalletJpa.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/springdata/SpringWalletJpa.java
@@ -16,5 +16,7 @@ public interface SpringWalletJpa extends JpaRepository<WalletEntity, Long> {
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("select w from WalletEntity w where w.id = :id")
-	Optional<WalletEntity> findByIdForUpdate(@Param("id") Long id);
+	Optional<WalletEntity> findByUserId(@Param("id") Long id);
+
+
 }

--- a/src/test/java/kr/hhplus/be/server/application/RechargePointUseCaseIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/RechargePointUseCaseIntegrationTest.java
@@ -1,0 +1,172 @@
+package kr.hhplus.be.server.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import kr.hhplus.be.server.application.usecase.RechargePointUseCase;
+import kr.hhplus.be.server.config.manager.DistributedLockManager;
+import kr.hhplus.be.server.domain.model.Money;
+import kr.hhplus.be.server.domain.model.PointWallet;
+import kr.hhplus.be.server.domain.port.WalletPort;
+import kr.hhplus.be.server.infrastructure.persistence.adapter.WalletJpaAdapter;
+import kr.hhplus.be.server.infrastructure.persistence.springdata.SpringReservationJpa;
+import kr.hhplus.be.server.infrastructure.persistence.springdata.SpringReservationSeatJpa;
+import kr.hhplus.be.server.infrastructure.persistence.springdata.SpringSeatStateJpa;
+import kr.hhplus.be.server.infrastructure.persistence.springdata.SpringShowJpa;
+import kr.hhplus.be.server.infrastructure.persistence.springdata.SpringShowSeatJpa;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EnableJpaRepositories(basePackages = "kr.hhplus.be.server.infrastructure.persistence.springdata")
+@EntityScan(basePackages = "kr.hhplus.be.server.infrastructure.persistence.entity")
+@Import({
+	RechargePointUseCase.class,
+	WalletJpaAdapter.class,
+	DistributedLockManager.class,
+	RechargePointUseCaseIntegrationTest.TestRedissonConfig.class
+})
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class RechargePointUseCaseIntegrationTest {
+
+	// 테스트와 무관한 Repository Mock
+	@MockitoBean
+	private SpringReservationJpa springReservationJpa;
+
+	@MockitoBean
+	private SpringReservationSeatJpa springReservationSeatJpa;
+
+	@MockitoBean
+	private SpringSeatStateJpa springSeatStateJpa;
+
+	@MockitoBean
+	private SpringShowJpa springShowJpa;
+
+	@MockitoBean
+	private SpringShowSeatJpa springShowSeatJpa;
+
+	@Container
+	static GenericContainer<?> redisContainer =
+		new GenericContainer<>("redis:7.0-alpine")
+			.withExposedPorts(6379);
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		// H2 설정
+		registry.add("spring.datasource.url",
+			() -> "jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1");
+		registry.add("spring.datasource.driver-class-name", () -> "org.h2.Driver");
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+	}
+
+	// 테스트용 RedissonConfig
+	@org.springframework.context.annotation.Configuration
+	static class TestRedissonConfig {
+		@org.springframework.context.annotation.Bean
+		public org.redisson.api.RedissonClient redissonClient() {
+			org.redisson.config.Config config = new org.redisson.config.Config();
+			String redisAddress = String.format("redis://%s:%d",
+				redisContainer.getHost(),
+				redisContainer.getMappedPort(6379));
+			config.useSingleServer()
+				.setAddress(redisAddress)
+				.setConnectionPoolSize(50)
+				.setConnectionMinimumIdleSize(10);
+			return org.redisson.Redisson.create(config);
+		}
+	}
+
+	@Autowired
+	private RechargePointUseCase rechargePointUseCase;
+
+	@Autowired
+	private WalletPort walletPort;
+
+	private static final Long TEST_USER_ID = 1L;
+	private static final Money CHARGE_AMOUNT = Money.of(1000L);
+
+	@BeforeEach
+	void setUp() {
+		walletPort.findByUserId(TEST_USER_ID);
+	}
+
+	@Test
+	@DisplayName("분산락 동시성 테스트")
+	void concurrencyWithDistributedLock() throws InterruptedException {
+		// given
+		int threadCount = 50;
+		ExecutorService executorService = Executors.newFixedThreadPool(10);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		AtomicInteger successCount = new AtomicInteger(0);
+		AtomicInteger failCount = new AtomicInteger(0);
+
+		// when
+		long startTime = System.currentTimeMillis();
+
+		for (int i = 0; i < threadCount; i++) {
+			final int index = i;
+			executorService.submit(() -> {
+				try {
+					rechargePointUseCase.handleWithDistributedLock(
+						TEST_USER_ID,
+						CHARGE_AMOUNT,
+						"request-" + index
+					);
+					successCount.incrementAndGet();
+				} catch (Exception e) {
+					failCount.incrementAndGet();
+					System.err.println("요청 " + index + " 실패: " + e.getMessage());
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+		executorService.shutdown();
+		executorService.awaitTermination(30, TimeUnit.SECONDS);
+
+		// 트랜잭션 반영 대기
+		Thread.sleep(500);
+
+		long duration = System.currentTimeMillis() - startTime;
+
+		// then
+		PointWallet after = walletPort.findByUserId(TEST_USER_ID);
+		Money expectedBalance = CHARGE_AMOUNT.multiply(successCount.get());
+
+		System.out.println("\n=== 분산락 동시성 테스트 ===");
+		System.out.println("소요 시간: " + duration + "ms");
+		System.out.println("성공: " + successCount.get() + "/" + threadCount);
+		System.out.println("실패: " + failCount.get());
+		System.out.println("예상 잔액: " + expectedBalance.asLong());
+		System.out.println("실제 잔액: " + after.getBalance().asLong());
+
+		assertThat(successCount.get()).isGreaterThan(0);
+		assertThat(after.getBalance()).isEqualTo(expectedBalance);
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/application/RechargePointUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/RechargePointUseCaseTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import kr.hhplus.be.server.application.usecase.RechargePointUseCase;
+import kr.hhplus.be.server.config.manager.DistributedLockManager;
 import kr.hhplus.be.server.domain.model.Money;
 import kr.hhplus.be.server.domain.model.PointWallet;
 import kr.hhplus.be.server.domain.port.WalletPort;
@@ -19,12 +20,14 @@ import kr.hhplus.be.server.domain.port.WalletPort;
 public class RechargePointUseCaseTest {
 	@Mock
 	WalletPort walletPort;
+	@Mock
+	DistributedLockManager lockManager;
 
 	@Test
 	@DisplayName("충전 성공")
 	void recharge_success() {
 		// Mock 객체로 주입된 RechargePointUseCase 생성
-		RechargePointUseCase sut = new RechargePointUseCase(walletPort);
+		RechargePointUseCase sut = new RechargePointUseCase(walletPort, lockManager);
 
 		Long userId = 9L;
 		Money amount = Money.of(30000);
@@ -47,7 +50,7 @@ public class RechargePointUseCaseTest {
 	@Test
 	@DisplayName("동일한 요청 ID로 충전 요청이 다시 들어왔을 때, 중복 처리 방지")
 	void recharge_idempotent() {
-		RechargePointUseCase sut = new RechargePointUseCase(walletPort);
+		RechargePointUseCase sut = new RechargePointUseCase(walletPort, lockManager);
 		Long userId = 9L;
 		Money amount = Money.of(30000);
 		String reqId = "charge-001";


### PR DESCRIPTION

이번 과제에서 구현한 기능은 포인트 충전 시 다수의 요청이 동시에 들어올 경우 발생할 수 있는 데이터 정합성 문제를 해결하기 위해 Redis 기반의 분산락을 도입하였습니다.

### **커밋 설명**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 커밋입니다.
코드를 작성할 때 커밋을 작업 단위로 잘 쪼개주세요!

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

- 분산락 모듈화: 48b7f16
- Point 충전 usecase에 분산락 적용 코드: 0bec84
- 분산락 테스트 코드 작성: 5aa0f1


---
### **리뷰 받고 싶은 내용(질문)**
- 커밋: 48b7f16
- 내용: 분산락 모듈화 코드를 커밋 내용과 같이 작성하여 사용하는것이 올바른지, 아니면 필요할 때 마다 직접 정의해서 사용하는것이 올바른지 궁금합니다.

- 커밋: 0bec84
- 내용: lockKey를 "wallet:recharge:"로 지정했는데. 충전 기능에만 국한된 락을 거는 것이 맞는지, 아니면 포인트 사용(결제) 등 다른 지갑 변경 로직과의 동시성을 고려해 더 포괄적인 키를 사용해야 하는지 고민입니다.

- 커밋: 5aa0f1
- 내용: 테스트에서 요청이 실제로 순서대로 처리되었는지(타임스탬프나 로그 등)까지 검증하는 게 좋을까요, 아니면 최종 결과값(잔액)만 맞아도 충분할까요?

<!-- - 코드 리뷰에서 피드백 받고 싶은 포인트가 있다면 추가로 작성해주세요
  
  좋은 예:
  - 커밋 : 동시성 테스트 코드 d93ji3 
  - 내용 `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  
  - 커밋 : 동시성 처리 c83845 / 혹은 파일명
  - 내용 : 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---

### 기술적 성장
<!-- 예시
- 새로 학습한 개념
- 기존 지식의 재발견/심화
- 구현 과정에서의 기술적 도전과 해결
-->

- Testcontainers를 도입해 외부 의존성(Redis 등)을 격리된 환경에서 테스트하는 방법을 학습했습니다.
- Redisson을 활용한 분산락을 구현하고 이해할 수 있게 되었습니다.

