### PR TITLE
[Step8] 이벤트 기반 아키텍처 도입

### DIFF
--- a/src/main/java/kr/hhplus/be/server/application/usecase/ConfirmReservationUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/application/usecase/ConfirmReservationUseCase.java
@@ -3,9 +3,11 @@ package kr.hhplus.be.server.application.usecase;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.hhplus.be.server.domain.event.ReservationConfirmedEvent;
 import kr.hhplus.be.server.domain.model.Money;
 import kr.hhplus.be.server.domain.model.PointWallet;
 import kr.hhplus.be.server.domain.model.Reservation;
@@ -19,48 +21,75 @@ import kr.hhplus.be.server.infrastructure.persistence.springdata.SpringShowSeatJ
 
 @Service
 public class ConfirmReservationUseCase {
+
 	private final ReservationPort reservationPort;
 	private final WalletPort walletPort;
 	private final SeatInventoryPort seatInventory;
-	private final SpringShowSeatJpa  showSeatJpa;
+	private final SpringShowSeatJpa showSeatJpa;
+	private final ApplicationEventPublisher eventPublisher;
 
 	public ConfirmReservationUseCase(ReservationPort reservationPort,
 		WalletPort walletPort,
 		SeatInventoryPort seatInventory,
-		SpringShowSeatJpa showSeatJpa) {
+		SpringShowSeatJpa showSeatJpa,
+		ApplicationEventPublisher eventPublisher) {
+
 		this.reservationPort = reservationPort;
 		this.walletPort = walletPort;
 		this.seatInventory = seatInventory;
 		this.showSeatJpa = showSeatJpa;
+		this.eventPublisher = eventPublisher;
 	}
 
+	/**
+	 * 예약 ID 기반으로 확정 (지금 ReservationController에서 사용하는 버전)
+	 */
 	@Transactional
 	public Result handle(Long reservationId, Long userId, Money amount, String idempotencyKey) {
+		// 1) 예약 & 지갑 조회 (비관락)
 		Reservation reservation = reservationPort.findByIdForUpdate(reservationId)
 			.orElseThrow(() -> new IllegalArgumentException("reservation not found"));
 
 		PointWallet wallet = walletPort.findByUserIdForUpdate(userId);
 
-		// 지갑 차감
+		// 2) 지갑 차감
 		wallet.deduct(amount, idempotencyKey);
 
-		// 좌석 확정
+		// 3) 좌석 확정
 		for (Integer seatNo : reservation.getSeatNos()) {
 			boolean ok = seatInventory.markConfirmed(reservation.getShowId(), seatNo);
-			if (!ok) throw new SeatStateRaceException(reservation.getShowId(), seatNo);
+			if (!ok) {
+				throw new SeatStateRaceException(reservation.getShowId(), seatNo);
+			}
 		}
 
-		// 예약 확정
-		reservation.confirm(LocalDateTime.now(), amount, userId);
+		// 4) 예약 도메인 상태 변경(HELD -> CONFIRMED)
+		LocalDateTime now = LocalDateTime.now();
+		reservation.confirm(now, amount, userId);
 
-		// 저장
+		// 5) 저장
 		reservationPort.save(reservation);
 		walletPort.save(wallet);
 		// PointHistory 기록은 adapter에서 처리 예정
 
+		// 6) 도메인 이벤트 발행 (트랜잭션 안에서는 "사실"만 던짐)
+		var event = new ReservationConfirmedEvent(
+			reservation.getReservationId(),
+			reservation.getUserId(),
+			reservation.getShowId(),
+			reservation.getSeatNos(),
+			amount,
+			now
+		);
+		eventPublisher.publishEvent(event);
+
 		return new Result("OK", wallet.getBalance());
 	}
 
+	/**
+	 * (기존 두번째 confirm 메서드, 필요하다면 그대로 유지)
+	 * userId, showId, 좌석 리스트 기반으로 바로 확정하는 버전
+	 */
 	@Transactional
 	public void confirm(Long userId, Long showId, List<Integer> seatNos) {
 
@@ -81,7 +110,9 @@ public class ConfirmReservationUseCase {
 		boolean ok = seatNos.stream()
 			.allMatch(no -> seatInventory.markConfirmed(showId, no));
 		if (!ok) {
-			throw new ReservationExpiredException(reservationPort.findByIdForUpdate(showId).get().getReservationId());
+			throw new ReservationExpiredException(
+				reservationPort.findByIdForUpdate(showId).get().getReservationId()
+			);
 		}
 
 		// 잔액 차감 & 저장
@@ -90,8 +121,10 @@ public class ConfirmReservationUseCase {
 
 		// 예약 포트(도메인 기록/이벤트 등)는 마지막에 호출
 		reservationPort.markConfirmed(userId, showId, seatNos);
+
+		// 이 confirm(...) 버전에서도 이벤트를 발행하고 싶다면
+		// 여기서도 ReservationConfirmedEvent 를 만들어서 publishEvent 해주면 됨
 	}
 
 	public record Result(String status, Money walletBalance) {}
-
 }

--- a/src/main/java/kr/hhplus/be/server/config/jpa/RestClientConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/jpa/RestClientConfig.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.config.jpa;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestClientConfig {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/domain/event/ReservationConfirmedEvent.java
+++ b/src/main/java/kr/hhplus/be/server/domain/event/ReservationConfirmedEvent.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import kr.hhplus.be.server.domain.model.Money;
+
+public record ReservationConfirmedEvent(
+	Long reservationId,
+	Long userId,
+	Long showId,
+	List<Integer> seatNos,
+	Money amount,
+	LocalDateTime confirmedAt
+) {
+}

--- a/src/main/java/kr/hhplus/be/server/domain/port/DataPlatformPort.java
+++ b/src/main/java/kr/hhplus/be/server/domain/port/DataPlatformPort.java
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.domain.port;
+
+import java.util.List;
+
+public interface DataPlatformPort {
+
+	void sendReservationConfirmed(ReservationConfirmedPayload payload);
+
+	record ReservationConfirmedPayload(
+		Long reservationId,
+		Long userId,
+		Long showId,
+		List<Integer> seatNos,
+		long amount,
+		String confirmedAt // ISO-8601 string (예: 2025-12-09T12:34:56)
+	) {
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/dataplatform/HttpDataPlatformAdapter.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/dataplatform/HttpDataPlatformAdapter.java
@@ -1,0 +1,34 @@
+package kr.hhplus.be.server.infrastructure.dataplatform;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import kr.hhplus.be.server.domain.port.DataPlatformPort;
+
+@Component
+public class HttpDataPlatformAdapter implements DataPlatformPort {
+
+	private static final Logger log = LoggerFactory.getLogger(HttpDataPlatformAdapter.class);
+
+	private final RestTemplate restTemplate;
+
+	// 과제용 mock API 엔드포인트
+	private final String endpointUrl = "http://localhost:8080/mock/reservations";
+
+	public HttpDataPlatformAdapter(RestTemplate restTemplate) {
+		this.restTemplate = restTemplate;
+	}
+
+	@Override
+	public void sendReservationConfirmed(ReservationConfirmedPayload payload) {
+		try {
+			restTemplate.postForEntity(endpointUrl, payload, Void.class);
+			log.info("Sent reservation to data-platform. payload={}", payload);
+		} catch (Exception e) {
+			// 예약 트랜잭션에 영향을 주면 안 되므로 여기서는 로깅만
+			log.error("Failed to send reservation to data-platform", e);
+		}
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/event/ReservationConfirmedEventHandler.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/event/ReservationConfirmedEventHandler.java
@@ -1,0 +1,35 @@
+package kr.hhplus.be.server.infrastructure.event;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+import kr.hhplus.be.server.domain.event.ReservationConfirmedEvent;
+import kr.hhplus.be.server.domain.port.DataPlatformPort;
+
+@Component
+public class ReservationConfirmedEventHandler {
+
+	private final DataPlatformPort dataPlatformPort;
+
+	public ReservationConfirmedEventHandler(DataPlatformPort dataPlatformPort) {
+		this.dataPlatformPort = dataPlatformPort;
+	}
+
+	/**
+	 * 예약 확정 트랜잭션이 커밋된 이후(AFTER_COMMIT)에만 동작
+	 */
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void onReservationConfirmed(ReservationConfirmedEvent event) {
+		var payload = new DataPlatformPort.ReservationConfirmedPayload(
+			event.reservationId(),
+			event.userId(),
+			event.showId(),
+			event.seatNos(),
+			event.amount().asLong(),
+			event.confirmedAt().toString()
+		);
+
+		dataPlatformPort.sendReservationConfirmed(payload);
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/web/MockDataPlatformController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/web/MockDataPlatformController.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.interfaces.web;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.hhplus.be.server.domain.port.DataPlatformPort;
+
+@RestController
+@RequestMapping("/mock")
+public class MockDataPlatformController {
+
+	private static final Logger log = LoggerFactory.getLogger(MockDataPlatformController.class);
+
+	@PostMapping("/reservations")
+	public void receiveReservation(@RequestBody DataPlatformPort.ReservationConfirmedPayload payload) {
+		log.info("Mock data-platform received reservation: {}", payload);
+		// 여기서는 그냥 로그만 찍지만, 필요하면 메모리/DB 저장도 가능
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/application/ConfirmReservationUseCaseTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/ConfirmReservationUseCaseTest.java
@@ -2,18 +2,19 @@ package kr.hhplus.be.server.application;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
+import org.springframework.context.ApplicationEventPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import kr.hhplus.be.server.application.usecase.ConfirmReservationUseCase;
+import kr.hhplus.be.server.domain.event.ReservationConfirmedEvent;
 import kr.hhplus.be.server.domain.model.Money;
 import kr.hhplus.be.server.domain.model.PointWallet;
 import kr.hhplus.be.server.domain.model.Reservation;
@@ -28,6 +29,8 @@ import kr.hhplus.be.server.infrastructure.persistence.springdata.SpringShowSeatJ
 @ExtendWith(MockitoExtension.class)
 public class ConfirmReservationUseCaseTest {
 
+	private static final Logger logger = LoggerFactory.getLogger(ConfirmReservationUseCaseTest.class);  // 로거 설정
+
 	@Mock
 	ReservationPort reservationPort;
 	@Mock
@@ -36,6 +39,8 @@ public class ConfirmReservationUseCaseTest {
 	SeatInventoryPort seatInventory;
 	@Mock
 	SpringShowSeatJpa showSeatJpa;
+	@Mock
+	ApplicationEventPublisher applicationEventPublisher;
 
 	private Reservation heldReservation(Long userId, Long showId, List<Integer> seats,
 		Money price, LocalDateTime expiresAt) {
@@ -54,9 +59,62 @@ public class ConfirmReservationUseCaseTest {
 
 	@Test
 	@DisplayName("예약 확정 성공 시: 지갑 차감 + 좌석 확정 + 상태 CONFIRMED")
+	void confirm_success_event() {
+		// given
+		ConfirmReservationUseCase sut = new ConfirmReservationUseCase(reservationPort, walletPort, seatInventory, showSeatJpa, applicationEventPublisher);
+
+		Long reservationId = 1L;
+		Long userId = 11L;
+		Long showId = 101L;
+		List<Integer> seats = List.of(5);
+		Money price = Money.of(15000);
+		LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(3);
+
+		logger.info("예약 처리 시작: reservationId={}, userId={}, showId={}", reservationId, userId, showId); // 예약 시작 로그
+
+		// 예약 진행
+		Reservation res = heldReservation(userId, showId, seats, price, expiresAt);
+
+		// 예약 이력 조회 정의
+		when(reservationPort.findByIdForUpdate(reservationId)).thenReturn(Optional.of(res));
+		// 결제 정보 조회 정의
+		when(walletPort.findByUserIdForUpdate(userId)).thenReturn(new PointWallet(userId, Money.of(50000)));
+		// 좌석 5번 확정 처리 정의
+		when(seatInventory.markConfirmed(showId, 5)).thenReturn(true);
+
+		logger.info("예약 처리 중: 결제 정보 및 좌석 확정 확인...");  // 처리 중간 단계 로그
+
+		// when (handle 실행)
+		var result = sut.handle(reservationId, userId, Money.of(15000), "idem-001");
+
+		logger.info("예약 처리 완료: status={}, walletBalance={}", result.status(), result.walletBalance().asLong());  // 처리 후 결과 로그
+
+		// then
+		// 값 검증
+		assertEquals("OK", result.status());
+		assertEquals(35000, result.walletBalance().asLong());
+		assertEquals(Reservation.Status.CONFIRMED, res.getStatus());
+
+		// 호출 검증
+		verify(reservationPort).findByIdForUpdate(reservationId);
+		verify(walletPort).findByUserIdForUpdate(userId);
+		verify(seatInventory).markConfirmed(showId, 5);
+		verify(reservationPort).save(res);
+		verify(walletPort).save(any(PointWallet.class));
+
+		// 이벤트 발행 검증 추가
+		logger.info("이벤트 발행: ReservationConfirmedEvent 발행.");
+		verify(applicationEventPublisher).publishEvent(any(ReservationConfirmedEvent.class));
+
+		verifyNoMoreInteractions(reservationPort, walletPort, seatInventory, applicationEventPublisher);
+		logger.info("예약 확정 성공: 모든 처리 완료.");
+	}
+
+	@Test
+	@DisplayName("예약 확정 성공 시: 지갑 차감 + 좌석 확정 + 상태 CONFIRMED")
 	void confirm_success() {
 		// given
-		ConfirmReservationUseCase sut = new ConfirmReservationUseCase(reservationPort, walletPort, seatInventory, showSeatJpa);
+		ConfirmReservationUseCase sut = new ConfirmReservationUseCase(reservationPort, walletPort, seatInventory, showSeatJpa, applicationEventPublisher);
 
 		Long reservationId = 1L;
 		Long userId = 11L;
@@ -97,7 +155,7 @@ public class ConfirmReservationUseCaseTest {
 	@DisplayName("만료된 예약은 확정 불가")
 	void confirm_expired() {
 		// given
-		ConfirmReservationUseCase sut = new ConfirmReservationUseCase(reservationPort, walletPort, seatInventory, showSeatJpa);
+		ConfirmReservationUseCase sut = new ConfirmReservationUseCase(reservationPort, walletPort, seatInventory, showSeatJpa, applicationEventPublisher);
 
 		Long reservationId = 1L;
 		Long userId = 11L;
@@ -122,7 +180,7 @@ public class ConfirmReservationUseCaseTest {
 	@Test
 	@DisplayName("지갑 잔액 부족 시 확정 불가")
 	void confirm_insufficientBalance() {
-		ConfirmReservationUseCase sut = new ConfirmReservationUseCase(reservationPort, walletPort, seatInventory, showSeatJpa);
+		ConfirmReservationUseCase sut = new ConfirmReservationUseCase(reservationPort, walletPort, seatInventory, showSeatJpa, applicationEventPublisher);
 
 		Long reservationId = 1L;
 		Long userId = 11L;

--- a/src/test/java/kr/hhplus/be/server/application/ReservationConfirmedEventHandlerTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/ReservationConfirmedEventHandlerTest.java
@@ -1,0 +1,50 @@
+package kr.hhplus.be.server.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import static org.mockito.Mockito.*;
+import java.time.LocalDateTime;
+import java.util.List;
+import kr.hhplus.be.server.domain.event.ReservationConfirmedEvent;
+import kr.hhplus.be.server.domain.model.Money;
+import kr.hhplus.be.server.domain.port.DataPlatformPort;
+import kr.hhplus.be.server.infrastructure.event.ReservationConfirmedEventHandler;
+
+@ExtendWith(MockitoExtension.class)
+public class ReservationConfirmedEventHandlerTest {
+
+	private static final Logger logger = LoggerFactory.getLogger(ReservationConfirmedEventHandlerTest.class); // 로거 설정
+
+	@Mock
+	private DataPlatformPort dataPlatformPort;
+
+	private ReservationConfirmedEventHandler handler;
+
+	@BeforeEach
+	void setup() {
+		handler = new ReservationConfirmedEventHandler(dataPlatformPort);
+	}
+
+	@Test
+	void testEventHandling() {
+		// Given
+		ReservationConfirmedEvent event = new ReservationConfirmedEvent(
+			1L, 11L, 101L, List.of(5), Money.of(15000), LocalDateTime.now());
+
+		// When
+		logger.info("Handling event: {}", event);  // 이벤트 처리 시작 로그
+		handler.onReservationConfirmed(event);
+
+		// Then
+		// 데이터 플랫폼 포트로 예약 정보가 전송되었는지 확인
+		verify(dataPlatformPort).sendReservationConfirmed(any(DataPlatformPort.ReservationConfirmedPayload.class));
+
+		// 이벤트 처리 후 확인 로그
+		logger.info("Event handled and reservation sent to platform successfully.");
+	}
+}


### PR DESCRIPTION
### **이번 PR에서 구현한 내용**
- 예약 확정 로직과 외부 데이터 전송 로직의 분리를 위해 Event를 도입했습니다.
- 예약 확정이 완료되면 이벤트를 발행하고, 이를 리스너가 받아 외부 데이터 플랫폼으로 전송합니다.
- @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)을 사용해 예약 트랜잭션이 완전히 커밋된 후에만 외부 요청이 실행되도록 구현했습니다.
- DataPlatformPort 인터페이스와 RestTemplate을 활용한 구현체를 통해 외부 시스템으로 예약 정보를 전송하도록 구현했습니다.

### **커밋 설명**
- 도메인 이벤트 및 포트 정의: 37f613c, 982f764
  - ReservationConfirmedEvent: 예약 확정 시 발행될 불변 이벤트 객체(Record) 정의
  - DataPlatformPort: 외부 데이터 플랫폼 통신을 위한 인터페이스 정의

- UseCase 이벤트 발행 로직 구현: 2e2d0dc, 6c02c13
  - ConfirmReservationUseCase: 예약 확정 후 ApplicationEventPublisher를 통해 이벤트 발행
  - 트랜잭션 내부에서는 비즈니스 로직만 수행하고, 외부 통신 로직 제거

- 이벤트 핸들러 구현: 7f02d5e
  - ReservationConfirmedEventHandler: AFTER_COMMIT 단계에서 이벤트를 수신하여 처리
  - 데이터 플랫폼 전송 실패가 예약 트랜잭션을 롤백시키지 않도록 분리

- 외부 통신 인프라 구현: 947169e, 4b00584
  - RestClientConfig: RestTemplate 빈 설정 추가
  - HttpDataPlatformAdapter: 실제 HTTP 요청을 보내는 어댑터 구현

- 테스트 및 검증용 Mock API: e0a51fc, 318dbfe
  - MockDataPlatformController: 로컬 테스트를 위해 데이터 수신 로그를 찍는 Mock API 구현


### **리뷰 받고 싶은 내용(질문)**
- 커밋: 7f02d5e (ReservationConfirmedEventHandler)
  - 질문: 외부 데이터 플랫폼으로 정보를 보내는 로직이 느려지면, 사용자가 받는 예약 완료 응답도 같이 느려질까 봐 걱정입니다.
  - 현재는 AFTER_COMMIT 옵션만 사용 중인데, 여기에 @Async를 붙여서 아예 별도 스레드로 분리하는 게 맞을까요?

- 커밋: 2e2d0dc (ConfirmReservationUseCase)
  - 질문: 트랜잭션이 다 끝난 뒤(커밋 후)에 외부로 데이터를 보내다가 에러가 나면, 예약은 성공했는데 데이터 전송만 실패하는 상황이 발생할 것 같습니다.
  - 이럴 때 보통 어떤 방식의 재시도 전략을 가져가는 것이 좋을까요? (Spring Retry 라이브러리를 붙이는 게 나을지, 아니면 다른 방법이 있는지 궁금합니다.)

### 기술적 성장
- 이벤트를 통해 도메인 로직과 부가 로직을 분리함으로써 결합도를 낮추는 방법을 배웠으며, 트랜잭션 생명주기에 맞춰 이벤트 리스너가 동작하는 시점을 제어하는 방법 알게되었습니다.
- 외부 API 호출 로직을 DataPlatformPort로 추상화함으로써, 실제 외부 서버 없이 MockDataPlatformController를 만들어 쉽게 테스트하고 개발 가능하다는걸 익혔습니다.