### PR TITLE
[Step9] Kafka로 대규모 확장 설계

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+	// kafka
+	implementation("org.springframework.kafka:spring-kafka:3.1.2")
+
     // DB
 	runtimeOnly("com.mysql:mysql-connector-j")
 
@@ -52,6 +55,8 @@ dependencies {
 	testImplementation("org.testcontainers:mysql")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testImplementation("org.jboss.logging:jboss-logging:3.5.3.Final")
+	testImplementation("org.springframework.kafka:spring-kafka-test:3.1.2")
+	testImplementation("org.testcontainers:kafka:1.19.3")
 
 	// H2 (인메모리)
 	testImplementation("com.h2database:h2")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,158 @@
-version: '3'
+version: '3.8'
+
 services:
+  # MySQL Database
   mysql:
     image: mysql:8.0
+    container_name: mysql
     ports:
       - "3307:3306"
     environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=application
-      - MYSQL_PASSWORD=application
-      - MYSQL_DATABASE=hhplus
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: application
+      MYSQL_PASSWORD: application
+      MYSQL_DATABASE: hhplus
     volumes:
       - ./data/mysql/:/var/lib/mysql
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Redis
+  redis:
+    image: redis:7.2-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    command: redis-server --appendonly yes
+    volumes:
+      - ./data/redis:/data
+
+  # Zookeeper (Kafka 코디네이터)
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.6.0
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "2181"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Kafka Broker 1
+  broker1:
+    image: confluentinc/cp-kafka:7.6.0
+    hostname: broker1
+    container_name: broker1
+    ports:
+      - "9092:9092"
+      - "19092:19092"
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker1:19092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:19092,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_LOG_RETENTION_MS: 604800000
+      KAFKA_LOG_RETENTION_BYTES: 1073741824
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "broker1:19092"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 40s
+
+  # Kafka Broker 2
+  broker2:
+    image: confluentinc/cp-kafka:7.6.0
+    hostname: broker2
+    container_name: broker2
+    ports:
+      - "9093:9093"
+      - "19093:19093"
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker2:19093,PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:19093,PLAINTEXT_HOST://0.0.0.0:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_LOG_RETENTION_MS: 604800000
+      KAFKA_LOG_RETENTION_BYTES: 1073741824
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "broker2:19093"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 40s
+
+  # Kafka Broker 3
+  broker3:
+    image: confluentinc/cp-kafka:7.6.0
+    hostname: broker3
+    container_name: broker3
+    ports:
+      - "9094:9094"
+      - "19094:19094"
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker3:19094,PLAINTEXT_HOST://localhost:9094
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:19094,PLAINTEXT_HOST://0.0.0.0:9094
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_LOG_RETENTION_MS: 604800000
+      KAFKA_LOG_RETENTION_BYTES: 1073741824
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions", "--bootstrap-server", "broker3:19094"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 40s
 
 networks:
-  default:
+  app-network:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/server/ServerApplication.java
+++ b/src/main/java/kr/hhplus/be/server/ServerApplication.java
@@ -2,8 +2,10 @@ package kr.hhplus.be.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
+@EnableJpaRepositories(basePackages = "kr.hhplus.be.server.infrastructure.persistence.springdata")
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/hhplus/be/server/config/kafka/AsyncConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/kafka/AsyncConfig.java
@@ -1,0 +1,56 @@
+package kr.hhplus.be.server.config.kafka;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * 비동기 처리 설정
+ *
+ * @Async 어노테이션을 사용하기 위한 설정
+ * 도메인 이벤트를 Kafka로 발행할 때 비동기로 처리
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+	/**
+	 * 이벤트 처리용 ThreadPool 설정
+	 *
+	 * 설정값:
+	 * - Core Pool Size: 기본 스레드 수
+	 * - Max Pool Size: 최대 스레드 수
+	 * - Queue Capacity: 대기 큐 크기
+	 */
+	@Bean(name = "eventTaskExecutor")
+	public Executor eventTaskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+		// 기본 스레드 수
+		executor.setCorePoolSize(5);
+
+		// 최대 스레드 수
+		executor.setMaxPoolSize(10);
+
+		// 대기 큐 크기
+		executor.setQueueCapacity(100);
+
+		// 스레드 이름 prefix
+		executor.setThreadNamePrefix("event-async-");
+
+		// 거부 정책: 호출자의 스레드에서 실행
+		executor.setRejectedExecutionHandler(
+			new java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy()
+		);
+
+		// 종료 대기 설정
+		executor.setWaitForTasksToCompleteOnShutdown(true);
+		executor.setAwaitTerminationSeconds(60);
+
+		executor.initialize();
+		return executor;
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,52 @@
+package kr.hhplus.be.server.config.kafka;
+
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+
+/**
+ * Kafka Consumer 설정
+ *
+ * Spring Boot의 KafkaProperties를 사용하여 application.yml 설정 자동 주입
+ */
+@Configuration
+public class KafkaConsumerConfig {
+
+	private final KafkaProperties kafkaProperties;
+
+	public KafkaConsumerConfig(KafkaProperties kafkaProperties) {
+		this.kafkaProperties = kafkaProperties;
+	}
+
+	@Bean
+	public ConsumerFactory<String, Object> consumerFactory() {
+		return new DefaultKafkaConsumerFactory<>(
+			kafkaProperties.buildConsumerProperties(null)
+		);
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+
+		factory.setConsumerFactory(consumerFactory());
+
+		// Listener 설정 적용
+		factory.getContainerProperties().setAckMode(
+			kafkaProperties.getListener().getAckMode()
+		);
+
+		// Concurrency 설정
+		Integer concurrency = kafkaProperties.getListener().getConcurrency();
+		if (concurrency != null) {
+			factory.setConcurrency(concurrency);
+		}
+
+		return factory;
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/config/kafka/KafkaProducerConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/kafka/KafkaProducerConfig.java
@@ -1,0 +1,35 @@
+package kr.hhplus.be.server.config.kafka;
+
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+/**
+ * Kafka Producer 설정
+ *
+ * Spring Boot의 KafkaProperties를 사용하여 application.yml 설정 자동 주입
+ */
+@Configuration
+public class KafkaProducerConfig {
+
+	private final KafkaProperties kafkaProperties;
+
+	public KafkaProducerConfig(KafkaProperties kafkaProperties) {
+		this.kafkaProperties = kafkaProperties;
+	}
+
+	@Bean
+	public ProducerFactory<String, Object> producerFactory() {
+		return new DefaultKafkaProducerFactory<>(
+			kafkaProperties.buildProducerProperties(null)
+		);
+	}
+
+	@Bean
+	public KafkaTemplate<String, Object> kafkaTemplate() {
+		return new KafkaTemplate<>(producerFactory());
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/kafka/ReservationConfirmedKafkaEvent.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/kafka/ReservationConfirmedKafkaEvent.java
@@ -1,0 +1,118 @@
+package kr.hhplus.be.server.infrastructure.kafka;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+/**
+ * Kafka로 전송할 예약 확정 이벤트 DTO
+ *
+ * 도메인 이벤트(ReservationConfirmedEvent)를 Kafka 메시지로 변환한 형태
+ * 직렬화/역직렬화가 용이하도록 설계
+ */
+public class ReservationConfirmedKafkaEvent {
+
+	private Long reservationId;
+	private Long userId;
+	private Long showId;
+	private List<Integer> seatNos;
+	private Long amountPaid;  // Money 객체를 Long으로 변환
+
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime confirmedAt;
+
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime publishedAt;  // Kafka 발행 시각
+
+	// 기본 생성자 (Jackson 역직렬화용)
+	public ReservationConfirmedKafkaEvent() {}
+
+	public ReservationConfirmedKafkaEvent(
+		Long reservationId,
+		Long userId,
+		Long showId,
+		List<Integer> seatNos,
+		Long amountPaid,
+		LocalDateTime confirmedAt,
+		LocalDateTime publishedAt) {
+
+		this.reservationId = reservationId;
+		this.userId = userId;
+		this.showId = showId;
+		this.seatNos = seatNos;
+		this.amountPaid = amountPaid;
+		this.confirmedAt = confirmedAt;
+		this.publishedAt = publishedAt;
+	}
+
+	// Getters and Setters
+	public Long getReservationId() {
+		return reservationId;
+	}
+
+	public void setReservationId(Long reservationId) {
+		this.reservationId = reservationId;
+	}
+
+	public Long getUserId() {
+		return userId;
+	}
+
+	public void setUserId(Long userId) {
+		this.userId = userId;
+	}
+
+	public Long getShowId() {
+		return showId;
+	}
+
+	public void setShowId(Long showId) {
+		this.showId = showId;
+	}
+
+	public List<Integer> getSeatNos() {
+		return seatNos;
+	}
+
+	public void setSeatNos(List<Integer> seatNos) {
+		this.seatNos = seatNos;
+	}
+
+	public Long getAmountPaid() {
+		return amountPaid;
+	}
+
+	public void setAmountPaid(Long amountPaid) {
+		this.amountPaid = amountPaid;
+	}
+
+	public LocalDateTime getConfirmedAt() {
+		return confirmedAt;
+	}
+
+	public void setConfirmedAt(LocalDateTime confirmedAt) {
+		this.confirmedAt = confirmedAt;
+	}
+
+	public LocalDateTime getPublishedAt() {
+		return publishedAt;
+	}
+
+	public void setPublishedAt(LocalDateTime publishedAt) {
+		this.publishedAt = publishedAt;
+	}
+
+	@Override
+	public String toString() {
+		return "ReservationConfirmedKafkaEvent{" +
+			"reservationId=" + reservationId +
+			", userId=" + userId +
+			", showId=" + showId +
+			", seatNos=" + seatNos +
+			", amountPaid=" + amountPaid +
+			", confirmedAt=" + confirmedAt +
+			", publishedAt=" + publishedAt +
+			'}';
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/kafka/ReservationEventKafkaPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/kafka/ReservationEventKafkaPublisher.java
@@ -1,0 +1,95 @@
+package kr.hhplus.be.server.infrastructure.kafka;
+
+import java.time.LocalDateTime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import kr.hhplus.be.server.domain.event.ReservationConfirmedEvent;
+
+/**
+ * Spring 도메인 이벤트를 Kafka 메시지로 변환하는 리스너
+ *
+ * 역할:
+ * 1. 도메인 이벤트(ReservationConfirmedEvent) 수신
+ * 2. Kafka 이벤트(ReservationConfirmedKafkaEvent)로 변환
+ * 3. Kafka Producer를 통해 메시지 발행
+ */
+@Component
+public class ReservationEventKafkaPublisher {
+
+	private static final Logger log = LoggerFactory.getLogger(ReservationEventKafkaPublisher.class);
+
+	private final ReservationKafkaProducer kafkaProducer;
+
+	public ReservationEventKafkaPublisher(ReservationKafkaProducer kafkaProducer) {
+		this.kafkaProducer = kafkaProducer;
+	}
+
+	/**
+	 * 예약 확정 도메인 이벤트를 받아서 Kafka로 발행
+	 *
+	 * @TransactionalEventListener(phase = AFTER_COMMIT):
+	 * - 트랜잭션이 성공적으로 커밋된 후에만 실행
+	 * - 롤백되면 이벤트가 발행되지 않음
+	 *
+	 * @Async:
+	 * - 비동기 처리
+	 * - Kafka 전송 지연이 메인 트랜잭션에 영향을 주지 않음
+	 * - @EnableAsync 설정 필요
+	 */
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleReservationConfirmed(ReservationConfirmedEvent domainEvent) {
+		log.info("Received domain event - reservationId: {}, converting to Kafka event",
+			domainEvent.reservationId());
+
+		try {
+			// 도메인 이벤트 -> Kafka 이벤트 변환
+			ReservationConfirmedKafkaEvent kafkaEvent = new ReservationConfirmedKafkaEvent(
+				domainEvent.reservationId(),
+				domainEvent.userId(),
+				domainEvent.showId(),
+				domainEvent.seatNos(),
+				domainEvent.amount().asLong(),  // Money를 Long으로 변환
+				domainEvent.confirmedAt(),
+				LocalDateTime.now()  // Kafka 발행 시각
+			);
+
+			// Kafka로 발행
+			kafkaProducer.publishReservationConfirmed(kafkaEvent);
+
+			log.info("Successfully converted and published to Kafka - reservationId: {}",
+				domainEvent.reservationId());
+
+		} catch (Exception e) {
+			log.error("Failed to publish domain event to Kafka - reservationId: {}, error: {}",
+				domainEvent.reservationId(), e.getMessage(), e);
+
+			// 에러 처리 전략
+			// 1. 현재는 로그만 남김
+			// 2. 필요시 재시도 로직 추가
+			// 3. Dead Letter Queue 또는 실패 테이블에 기록
+			// 4. 모니터링 알림 전송
+		}
+	}
+
+	/**
+	 * 트랜잭션 커밋 전에 실행되는 버전 (선택적)
+	 *
+	 * BEFORE_COMMIT을 사용하면:
+	 * - 트랜잭션 내에서 실행되므로 동기적
+	 * - Kafka 전송 실패 시 트랜잭션 롤백 가능
+	 * - 하지만 성능 영향이 큼
+	 *
+	 * 일반적으로는 AFTER_COMMIT을 권장
+	 */
+	// @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+	// public void handleBeforeCommit(ReservationConfirmedEvent event) {
+	//     // 트랜잭션 커밋 전 실행
+	// }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/kafka/ReservationKafkaConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/kafka/ReservationKafkaConsumer.java
@@ -1,0 +1,215 @@
+package kr.hhplus.be.server.infrastructure.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+
+
+/**
+ * Kafka Consumer 서비스
+ *
+ * 예약 확정 이벤트를 소비하여 후속 처리를 수행
+ *
+ * 처리 예시:
+ * 1. 알림 발송 (SMS, 이메일, 푸시)
+ * 2. 데이터 분석 시스템으로 전달
+ * 3. 외부 시스템 연동 (결제, 재고 등)
+ * 4. 로그/감사 기록
+ */
+@Service
+public class ReservationKafkaConsumer {
+
+	private static final Logger log = LoggerFactory.getLogger(ReservationKafkaConsumer.class);
+
+	/**
+	 * 예약 확정 이벤트 소비
+	 *
+	 * @KafkaListener:
+	 * - topics: 구독할 토픽 이름
+	 * - groupId: Consumer Group ID
+	 * - containerFactory: 사용할 리스너 컨테이너 팩토리
+	 *
+	 * @Payload: 메시지 본문
+	 * @Header: 메시지 메타데이터
+	 * Acknowledgment: 수동 커밋용 객체
+	 */
+	@KafkaListener(
+		topics = "${kafka.topics.reservation-confirmed}",
+		groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "kafkaListenerContainerFactory"
+	)
+	public void consumeReservationConfirmed(
+		@Payload ReservationConfirmedKafkaEvent event,
+		@Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+		@Header(KafkaHeaders.OFFSET) long offset,
+		@Header(KafkaHeaders.RECEIVED_TIMESTAMP) long timestamp,
+		ConsumerRecord<String, ReservationConfirmedKafkaEvent> record,
+		Acknowledgment acknowledgment) {
+
+		log.info("Received reservation confirmed event - " +
+				"reservationId: {}, userId: {}, showId: {}, partition: {}, offset: {}, timestamp: {}",
+			event.getReservationId(),
+			event.getUserId(),
+			event.getShowId(),
+			partition,
+			offset,
+			timestamp);
+
+		try {
+			// ===== 비즈니스 로직 처리 =====
+
+			// 1. 알림 발송
+			sendNotification(event);
+
+			// 2. 데이터 분석 시스템으로 전송
+			sendToAnalytics(event);
+
+			// 3. 외부 시스템 연동
+			notifyExternalSystems(event);
+
+			// 4. 로그/감사 기록
+			logAuditTrail(event);
+
+			// ===== 처리 완료 후 수동 커밋 =====
+			acknowledgment.acknowledge();
+
+			log.info("Successfully processed and acknowledged - " +
+					"reservationId: {}, partition: {}, offset: {}",
+				event.getReservationId(), partition, offset);
+
+		} catch (Exception e) {
+			log.error("Error processing reservation confirmed event - " +
+					"reservationId: {}, partition: {}, offset: {}, error: {}",
+				event.getReservationId(),
+				partition,
+				offset,
+				e.getMessage(),
+				e);
+
+			// 에러 처리 전략
+			// 1. 재시도: acknowledgment를 호출하지 않으면 다음 poll에서 다시 받음
+			// 2. DLQ(Dead Letter Queue)로 전송
+			// 3. 에러 로그 기록 후 ack (데이터 손실 방지)
+
+			// 여기서는 일단 ack하여 무한 재시도 방지
+			// 실제로는 재시도 카운트를 추적하고 DLQ로 보내는 것이 좋음
+			acknowledgment.acknowledge();
+		}
+	}
+
+	/**
+	 * 알림 발송 처리
+	 */
+	private void sendNotification(ReservationConfirmedKafkaEvent event) {
+		log.info("Sending notification to user {} for reservation {}",
+			event.getUserId(), event.getReservationId());
+
+		// TODO: 실제 알림 발송 로직
+		// - SMS 발송
+		// - 이메일 발송
+		// - 푸시 알림 발송
+		// - 웹소켓을 통한 실시간 알림
+
+		// 예시:
+		// notificationService.sendReservationConfirmed(
+		//     event.getUserId(),
+		//     event.getReservationId(),
+		//     event.getShowId(),
+		//     event.getSeatNos()
+		// );
+	}
+
+	/**
+	 * 데이터 분석 시스템으로 전송
+	 */
+	private void sendToAnalytics(ReservationConfirmedKafkaEvent event) {
+		log.info("Sending analytics data for reservation {}", event.getReservationId());
+
+		// TODO: 분석 시스템 연동
+		// - Google Analytics 이벤트 전송
+		// - 사내 데이터 웨어하우스로 전송
+		// - 실시간 대시보드 업데이트
+
+		// 예시:
+		// analyticsService.trackReservationConfirmed(
+		//     event.getUserId(),
+		//     event.getShowId(),
+		//     event.getAmountPaid()
+		// );
+	}
+
+	/**
+	 * 외부 시스템 연동
+	 */
+	private void notifyExternalSystems(ReservationConfirmedKafkaEvent event) {
+		log.info("Notifying external systems for reservation {}", event.getReservationId());
+
+		// TODO: 외부 시스템 호출
+		// - 재고 관리 시스템 업데이트
+		// - 결제 시스템 최종 확인
+		// - CRM 시스템 업데이트
+		// - 파트너사 API 호출
+
+		// 예시:
+		// inventoryService.confirmReservation(event.getShowId(), event.getSeatNos());
+		// crmService.updateCustomerActivity(event.getUserId(), "RESERVATION_CONFIRMED");
+	}
+
+	/**
+	 * 감사 로그 기록
+	 */
+	private void logAuditTrail(ReservationConfirmedKafkaEvent event) {
+		log.info("Logging audit trail for reservation {}", event.getReservationId());
+
+		// TODO: 감사 로그 저장
+		// - 데이터베이스에 감사 로그 저장
+		// - 로그 수집 시스템으로 전송
+		// - 컴플라이언스 요구사항 충족
+
+		// 예시:
+		// auditLogRepository.save(new AuditLog(
+		//     "RESERVATION_CONFIRMED",
+		//     event.getUserId(),
+		//     event.getReservationId(),
+		//     event.getConfirmedAt()
+		// ));
+	}
+
+	/**
+	 * 배치 처리 Consumer (선택적)
+	 *
+	 * 여러 메시지를 한 번에 처리할 때 사용
+	 * 처리량이 높을 때 효율적
+	 */
+	// @KafkaListener(
+	//     topics = "${kafka.topics.reservation-confirmed}",
+	//     groupId = "${spring.kafka.consumer.group-id}",
+	//     containerFactory = "batchKafkaListenerContainerFactory"
+	// )
+	// public void consumeBatch(
+	//     List<ReservationConfirmedKafkaEvent> events,
+	//     Acknowledgment acknowledgment) {
+	//
+	//     log.info("Received batch of {} events", events.size());
+	//
+	//     try {
+	//         for (ReservationConfirmedKafkaEvent event : events) {
+	//             // 개별 이벤트 처리
+	//             processEvent(event);
+	//         }
+	//
+	//         acknowledgment.acknowledge();
+	//         log.info("Successfully processed batch of {} events", events.size());
+	//
+	//     } catch (Exception e) {
+	//         log.error("Error processing batch: {}", e.getMessage(), e);
+	//         acknowledgment.acknowledge();  // 또는 부분 재시도 로직
+	//     }
+	// }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/kafka/ReservationKafkaProducer.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/kafka/ReservationKafkaProducer.java
@@ -1,0 +1,144 @@
+package kr.hhplus.be.server.infrastructure.kafka;
+
+
+import java.util.concurrent.CompletableFuture;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+
+
+/**
+ * Kafka Producer 서비스
+ *
+ * 예약 확정 이벤트를 Kafka 토픽으로 발행하는 책임을 가진 서비스
+ *
+ * 주요 기능:
+ * 1. 메시지 발행
+ * 2. 파티셔닝 전략 (userId 기반)
+ * 3. 발행 성공/실패 로깅
+ */
+@Service
+public class ReservationKafkaProducer {
+
+	private static final Logger log = LoggerFactory.getLogger(ReservationKafkaProducer.class);
+
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+	private final String topicName;
+
+	public ReservationKafkaProducer(
+		KafkaTemplate<String, Object> kafkaTemplate,
+		@Value("${kafka.topics.reservation-confirmed}") String topicName) {
+
+		this.kafkaTemplate = kafkaTemplate;
+		this.topicName = topicName;
+	}
+
+	/**
+	 * 예약 확정 이벤트를 Kafka로 발행
+	 *
+	 * 파티셔닝 전략:
+	 * - Key: userId를 문자열로 사용
+	 * - 같은 userId의 메시지는 항상 같은 파티션으로 전송되어 순서 보장
+	 *
+	 * @param event 발행할 이벤트
+	 */
+	public void publishReservationConfirmed(ReservationConfirmedKafkaEvent event) {
+		// 파티션 키: userId (같은 사용자의 예약은 같은 파티션으로)
+		String key = String.valueOf(event.getUserId());
+
+		log.info("Publishing reservation confirmed event to Kafka - " +
+				"reservationId: {}, userId: {}, showId: {}, topic: {}",
+			event.getReservationId(), event.getUserId(), event.getShowId(), topicName);
+
+		// 비동기 전송
+		CompletableFuture<SendResult<String, Object>> future =
+			kafkaTemplate.send(topicName, key, event);
+
+		// 전송 결과 처리
+		future.whenComplete((result, ex) -> {
+			if (ex == null) {
+				// 성공
+				var metadata = result.getRecordMetadata();
+				log.info("Message sent successfully - " +
+						"topic: {}, partition: {}, offset: {}, timestamp: {}, key: {}",
+					metadata.topic(),
+					metadata.partition(),
+					metadata.offset(),
+					metadata.timestamp(),
+					key);
+			} else {
+				// 실패
+				log.error("Failed to send message to Kafka - " +
+						"reservationId: {}, userId: {}, error: {}",
+					event.getReservationId(),
+					event.getUserId(),
+					ex.getMessage(),
+					ex);
+
+				// 실패 시 대응 전략
+				// 1. 재시도는 Kafka Producer 설정의 retries로 자동 처리됨
+				// 2. 여기서는 로그만 남기고, 필요시 별도 실패 처리 로직 추가 가능
+				// 3. 예: Dead Letter Queue로 전송, DB에 실패 기록 등
+			}
+		});
+	}
+
+	/**
+	 * 동기 방식 발행 (필요한 경우)
+	 *
+	 * 전송이 완료될 때까지 대기
+	 * 성능은 떨어지지만 확실한 전송 보장이 필요할 때 사용
+	 */
+	public void publishReservationConfirmedSync(ReservationConfirmedKafkaEvent event)
+		throws Exception {
+
+		String key = String.valueOf(event.getUserId());
+
+		log.info("Publishing reservation confirmed event to Kafka (SYNC) - " +
+				"reservationId: {}, userId: {}",
+			event.getReservationId(), event.getUserId());
+
+		try {
+			SendResult<String, Object> result =
+				kafkaTemplate.send(topicName, key, event).get();  // 동기 대기
+
+			var metadata = result.getRecordMetadata();
+			log.info("Message sent successfully (SYNC) - " +
+					"topic: {}, partition: {}, offset: {}",
+				metadata.topic(), metadata.partition(), metadata.offset());
+
+		} catch (Exception e) {
+			log.error("Failed to send message to Kafka (SYNC) - " +
+					"reservationId: {}, error: {}",
+				event.getReservationId(), e.getMessage(), e);
+			throw e;
+		}
+	}
+
+	/**
+	 * 특정 파티션으로 직접 발행 (고급 사용)
+	 *
+	 * 파티션을 직접 지정해야 하는 특수한 경우에만 사용
+	 */
+	public void publishToPartition(ReservationConfirmedKafkaEvent event, int partition) {
+		String key = String.valueOf(event.getUserId());
+
+		log.info("Publishing to specific partition - " +
+				"reservationId: {}, partition: {}",
+			event.getReservationId(), partition);
+
+		kafkaTemplate.send(topicName, partition, key, event)
+			.whenComplete((result, ex) -> {
+				if (ex == null) {
+					log.info("Message sent to partition {} successfully", partition);
+				} else {
+					log.error("Failed to send to partition {}: {}",
+						partition, ex.getMessage(), ex);
+				}
+			});
+	}
+}

--- a/src/main/resources/applicaion-kafka.yml
+++ b/src/main/resources/applicaion-kafka.yml
@@ -1,0 +1,81 @@
+spring:
+  kafka:
+    # Kafka Bootstrap Servers (3개 브로커)
+    bootstrap-servers:
+      - localhost:9092
+      - localhost:9093
+      - localhost:9094
+
+    # Producer 설정
+    producer:
+      # 메시지 키/값 직렬화 방식
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+      # Acknowledgment 설정 (all = 모든 ISR 브로커로부터 확인)
+      acks: all
+
+      # 재시도 설정
+      retries: 3
+
+      # 배치 크기 (bytes)
+      batch-size: 16384
+
+      # Linger 시간 (밀리초) - 배치를 모으기 위해 대기하는 시간
+      properties:
+        linger.ms: 10
+        # 압축 타입
+        compression.type: snappy
+        # Idempotent Producer 활성화 (중복 방지)
+        enable.idempotence: true
+        # 최대 in-flight 요청 수
+        max.in.flight.requests.per.connection: 5
+
+    # Consumer 설정
+    consumer:
+      # Consumer Group ID
+      group-id: concert-reservation-consumer-group
+
+      # 메시지 키/값 역직렬화 방식
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+
+      # Auto Offset Commit 비활성화 (수동 커밋)
+      enable-auto-commit: false
+
+      # Offset 초기 위치 (earliest = 처음부터, latest = 최신부터)
+      auto-offset-reset: earliest
+
+      # 한 번에 가져올 레코드 수
+      max-poll-records: 100
+
+      # Consumer 설정들을 properties 아래로 통합
+      properties:
+        # JSON Deserializer 설정
+        spring.json.trusted.packages: "*"
+        spring.json.type.mapping: reservation-confirmed:kr.hhplus.be.server.infrastructure.kafka.event.ReservationConfirmedKafkaEvent
+        # Poll 타임아웃
+        max.poll.interval.ms: 300000
+
+    # Listener 설정
+    listener:
+      # Acknowledgment 모드 (MANUAL = 수동 커밋)
+      ack-mode: manual
+
+      # 동시성 (Consumer 스레드 수)
+      concurrency: 3
+
+      # 에러 핸들링
+      type: batch
+
+# Kafka 토픽 설정
+kafka:
+  topics:
+    reservation-confirmed: reservation-confirmed-topic
+
+  # 토픽 생성 설정
+  topic-config:
+    reservation-confirmed:
+      partitions: 3  # 파티션 수
+      replication-factor: 2  # 복제 팩터 (브로커 3대 중 2대에 복제)
+      retention-ms: 604800000  # 7일 보관 (밀리초)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,12 +11,16 @@ spring:
       connection-timeout: 10000
       max-lifetime: 60000
     driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3307/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
+    username: application
+    password: application
+
   jpa:
     open-in-view: false
     generate-ddl: false
     show-sql: false
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
@@ -26,17 +30,49 @@ spring:
       host: localhost
       port: 6379
 
+  # Kafka 설정 직접 포함
+  kafka:
+    bootstrap-servers:
+      - localhost:9092
+      - localhost:9093
+      - localhost:9094
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      retries: 3
+      batch-size: 16384
+      properties:
+        linger.ms: 10
+        compression.type: snappy
+        enable.idempotence: true
+        max.in.flight.requests.per.connection: 5
+    consumer:
+      group-id: concert-reservation-consumer-group
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      enable-auto-commit: false
+      auto-offset-reset: earliest
+      max-poll-records: 100
+      properties:
+        spring.json.trusted.packages: "*"
+        spring.json.type.mapping: reservation-confirmed:kr.hhplus.be.server.infrastructure.kafka.ReservationConfirmedKafkaEvent
+        max.poll.interval.ms: 300000
+    listener:
+      ack-mode: manual
+      concurrency: 3
+      type: batch
+
 # === 커스텀 설정 ===
 reservation:
   hold-ttl-seconds: 120
 
----
-spring.config.activate.on-profile: local, test
-
-spring:
-  datasource:
-    url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
-    username: application
-    password: application
-
-
+# Kafka 토픽 설정
+kafka:
+  topics:
+    reservation-confirmed: reservation-confirmed-topic
+  topic-config:
+    reservation-confirmed:
+      partitions: 3
+      replication-factor: 2
+      retention-ms: 604800000


### PR DESCRIPTION
### **이번 PR에서 구현한 내용**
- 예약 확정 로직과 외부 데이터 전송 로직의 분리를 위해 Kafka 기반 이벤트 시스템을 도입했습니다.
- 예약 확정이 완료되면 Kafka 토픽으로 메시지를 발행하고, Consumer가 이를 받아 외부 데이터 플랫폼으로 전송합니다.
- Spring Kafka의 Producer/Consumer 구조를 활용하여 예약 서비스와 데이터 전송 로직을 완전히 분리했습니다.
- Kafka 메시지 발행 실패가 예약 트랜잭션에 영향을 주지 않도록 비동기 방식으로 구현했습니다.

### **Kafka 정리 문서**
- https://www.notion.so/2ceb5b622f3b81d4bc89d39edeeb2fe6?source=copy_link

### **커밋 설명**
- Kafka 설정 추가: 6870766
  - 의존성 추가
  - application.yml, application-kafka.yml 설정파일 추가

- AsyncConfig 추가: 641f608
  - AsyncConfig 추가
  - 비동기 처리를 위한 ThreadPoolTaskExecutor 설정
  - Kafka Consumer의 독립적인 스레드 풀 구성

- 메시지 Producer 구현: 1d141bf
  - consumer, producer 파일 추가
  - KafkaTemplate을 활용한 메시지 발행 로직 구현
  - 예약 확정 정보를 Kafka 토픽으로 전송하는 Producer 작성

- 예약 서비스에 kafka 적용: 98157b2
  - ReservationConfirmedKafkaEvent: Kafka로 전송할 예약 확정 이벤트 객체 정의
  - ReservationEventKafkaPublisher: KafkaTemplate을 활용한 메시지 발행 로직 구현
  - ReservationKafkaConsumer: Kafka 메시지를 소비하여 외부 데이터 플랫폼으로 전송하는 Consumer 구현


### **리뷰 받고 싶은 내용(질문)**
- 커밋: 981757b2 (Kafka Event System)
  - 질문: Kafka Producer에서 메시지 발행 실패 시, 예약 트랜잭션을 롤백해야 할까요, 아니면 그냥 로그만 남기고 넘어가는 게 맞을까요? 현재는 비동기로 발행만 하고 있는데, acks 설정이나 재시도 정책을 어느 수준까지 가져가는 게 적절한지 궁금합니다

- 커밋: 641f608 (AsyncConfig)
  - 질문: Consumer가 별도 스레드에서 동작하는데, 스레드 풀 크기를 어떻게 설정하는 게 적절할까요? 


### 기술적 성장
- Kafka를 활용한 이벤트 기반 아키텍처를 통해 서비스 간 결합도를 낮추고, 시스템 확장성을 높이는 방법을 배웠습니다
- Spring Kafka의 Producer/Consumer 구조와 설정 방법을 익혔으며, 비동기 메시지 처리의 장단점을 이해하게 되었습니다
- 분산 시스템에서 메시지 유실, 재시도, 순서 보장 등의 문제를 고려해야 한다는 것을 알게 되었습니다.